### PR TITLE
INT-1141: match parent method signature

### DIFF
--- a/newsletter2go/controllers/admin/Newsletter2GoTabController.php
+++ b/newsletter2go/controllers/admin/Newsletter2GoTabController.php
@@ -86,7 +86,7 @@ class Newsletter2GoTabController extends AdminController
         return true;
     }
 
-    public function viewAccess()
+    public function viewAccess($disable = false)
     {
         return true;
     }


### PR DESCRIPTION
The overridden viewAccess() takes a boolean parameter and it seems that php does not tolerate the difference from 7.2 anymore. 
https://github.com/PrestaShop/PrestaShop-1.5/blob/master/classes/controller/AdminController.php#L427